### PR TITLE
add CI job to build and deploy documentation

### DIFF
--- a/.github/workflows/BuildDelopyDoc.yml
+++ b/.github/workflows/BuildDelopyDoc.yml
@@ -1,0 +1,31 @@
+name: Build and Deploy Documentation
+
+on:
+  push:
+    branches:
+      - master
+      - dev
+    tags: '*'
+  pull_request:
+
+jobs:
+  build:
+    permissions:
+      contents: write
+      statuses: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1.9'
+      - name: Add custom registry 
+        run: |
+          julia --project=docs/ -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/QEDjl-project/registry.git"));'
+          julia --project=docs/ -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/JuliaRegistries/General"));'
+      - name: Install dependencies
+        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+      - name: Build and deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token
+        run: julia --project=docs/ docs/make.jl

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # QEDevents
 
+[![Doc Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://qedjl-project.github.io/QEDevents.jl/main)
+[![Doc Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://qedjl-project.github.io/QEDevents.jl/dev)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,7 +6,7 @@ DocMeta.setdocmeta!(QEDevents, :DocTestSetup, :(using QEDevents); recursive = tr
 makedocs(;
     modules = [QEDevents],
     authors = "Uwe Hernandez Acosta <u.hernandez@hzdr.de>, Simeon Ehrig, Klaus Steiniger, Tom Jungnickel, Anton Reinhard",
-    repo = "https://github.com/QEDjl-project/QEDevents.jl/blob/{commit}{path}#{line}",
+    repo = Documenter.Remotes.GitHub("QEDjl-project", "QEDevents.jl"),
     sitename = "QEDevents.jl",
     format = Documenter.HTML(;
         prettyurls = get(ENV, "CI", "false") == "true",
@@ -15,3 +15,4 @@ makedocs(;
     ),
     pages = ["Home" => "index.md"],
 )
+deploydocs(repo = "github.com/QEDjl-project/QEDevents.jl.git", push_preview = false)


### PR DESCRIPTION
The PR builds only the documentation. We will see, if deploying is working, when we merge. Pull request previews are not possible, because of security reasons. Pushing to the `gh-pages` branch is only working, if the PR was open with source branch located in this repository (no forks).

The badges also does not work for the moment. They will work, if we push to `dev` and `main`.