### PR TITLE
run compat helper only on upstream repository

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -8,6 +8,7 @@ permissions:
   pull-requests: write
 jobs:
   CompatHelper:
+    if: github.repository == 'QEDjl-project/QEDfields.jl'
     runs-on: ubuntu-latest
     steps:
       - name: Check if Julia is already available in the PATH


### PR DESCRIPTION
This if-condition avoids, that the compat helper is executed in forks.

copy of: https://github.com/QEDjl-project/QEDfields.jl/pull/19