### PR TITLE
Uniform proposal sampler

### DIFF
--- a/src/QEDevents.jl
+++ b/src/QEDevents.jl
@@ -8,7 +8,10 @@ export AbstractSampler,
     weight,
     max_weight
 
+export UniformSampler
+
 import Random: AbstractRNG, MersenneTwister
+using Distributions
 import Distributions: rand, rand!, _rand!
 
 using QEDbase
@@ -17,5 +20,5 @@ using QEDprocesses
 using DocStringExtensions
 
 include("interfaces/sampler_interface.jl")
-
+include("sampler/proposal/uniform.jl")
 end

--- a/src/interfaces/sampler_interface.jl
+++ b/src/interfaces/sampler_interface.jl
@@ -37,7 +37,7 @@ Base.eltype(smplr::AbstractSampler) = throw(MethodError(eltype, (smplr,)))
 Interface function, which asserts that the given `input` is valid.
 """
 function QEDprocesses._assert_valid_input(smplr::AbstractSampler, x::AbstractVecOrMat)
-    size(x, 1) == size(smplr, 1)[1] || throw(
+    size(x, 1) == size(smplr, 1) || throw(
         InvalidInputError(
             "The dimensionality of the input is $(size(x,1)) but it should be $(size(smplr,1)[1]).",
         ),

--- a/src/interfaces/sampler_interface.jl
+++ b/src/interfaces/sampler_interface.jl
@@ -122,7 +122,6 @@ function rand(rng::AbstractRNG, smplr::AbstractSampler, N::Integer)
     return _rand!(rng, smplr, Matrix{eltype(smplr)}(undef, size(smplr, 1), N))
 end
 
-
 ####
 # Sampler related to scattering processes
 ####
@@ -172,7 +171,6 @@ Additionally, one needs to implement the training function, which adopts the giv
 abstract type AbstractProposalSampler <: AbstractSampler end
 is_exact(::AbstractProposalSampler) = false
 
-
 """
 
     train!(smplr::AbstractProposalSampler, train_params; loss=Nothing)
@@ -180,4 +178,3 @@ is_exact(::AbstractProposalSampler) = false
 Interface function to perfom the training of a proposal sampler. 
 """
 function train! end
-

--- a/src/sampler/proposal/uniform.jl
+++ b/src/sampler/proposal/uniform.jl
@@ -1,0 +1,36 @@
+######
+# Uniform Proposal Sampler
+#
+# This file contains all types and functionality to produce uniform samples for
+# a given setup.
+######
+
+
+
+struct UniformSampler{S<:AbstractComputationSetup,D} <: AbstractProposalSampler
+    # TODO: think about a default setup
+    stp::S
+    dist::D
+
+    function UniformSampler(stp::S,bounds::AbstractVector) where {S<: AbstractComputationSetup}
+        dist = product_distribution([Uniform(b...) for b in bounds])
+        return new{S,typeof(dist)}(stp,dist)
+    end
+end
+
+function train!(::UniformSampler) 
+    @warn "Uniform sampler does not need to be trained."
+    return nothing
+end
+
+# TODO: generalize this! -> write issue about this! 
+Base.eltype(::UniformSampler) = Float64
+
+function _weight(u::UniformSampler,x)
+    pdf(u.dist,x)
+end
+
+function _rand!(rng::AbstractRNG, u::UniformSampler, x::AbstractVecOrMat{T}) where {T<:Real}
+    return Distributions.rand!(rng, u.dist, x)
+end
+

--- a/src/sampler/proposal/uniform.jl
+++ b/src/sampler/proposal/uniform.jl
@@ -23,7 +23,7 @@ weight(uniform_sampler,[0.5,0.0,4.0])
 ```
 
 """
-struct UniformSampler{DIM,D} <: AbstractProposalSampler
+struct UniformSampler{D} <: AbstractProposalSampler
     dist::D
 
     function UniformSampler(lower_bounds::AbstractVector, upper_bounds::AbstractVector)

--- a/src/sampler/proposal/uniform.jl
+++ b/src/sampler/proposal/uniform.jl
@@ -5,26 +5,49 @@
 # a given setup.
 ######
 
+"""
 
+    UniformSampler(stp::QEDprocesses.AbstractComputationSetup, bounds::AbstractVector)
 
-struct UniformSampler{S<:AbstractComputationSetup,D} <: AbstractProposalSampler
-    # TODO: think about a default setup
-    stp::S
+# Example 
+```
+using QEDprocesses, QEDevents
+struct TestSetup <: AbstractComputationSetup end
+
+lower_bounds = [0,-1,3]
+upper_bounds = [1,1,8]
+
+uniform_sampler = UniformSampler(lower_bounds, upper_bounds)
+
+weight(uniform_sampler,[0.5,0.0,4.0])
+```
+
+"""
+struct UniformSampler{DIM,D} <: AbstractProposalSampler
     dist::D
 
-    function UniformSampler(stp::S,bounds::AbstractVector) where {S<: AbstractComputationSetup}
-        dist = product_distribution([Uniform(b...) for b in bounds])
-        return new{S,typeof(dist)}(stp,dist)
+    function UniformSampler(lower_bounds::AbstractVector,upper_bounds::AbstractVector) 
+        dist = product_distribution(Uniform.(lower_bounds,upper_bounds))
+        return new{typeof(dist)}(dist)
     end
 end
 
-function train!(::UniformSampler) 
+function setup(::UniformSampler) 
+    @warn "Uniform sampler does not need a setup."
+    return nothing
+end
+
+function train!(::UniformSampler, config...) 
     @warn "Uniform sampler does not need to be trained."
     return nothing
 end
 
 # TODO: generalize this! -> write issue about this! 
 Base.eltype(::UniformSampler) = Float64
+
+
+Base.size(s::UniformSampler) = size(s.dist)
+Base.size(s::UniformSampler, k) = size(s)[k]
 
 function _weight(u::UniformSampler,x)
     pdf(u.dist,x)

--- a/src/sampler/proposal/uniform.jl
+++ b/src/sampler/proposal/uniform.jl
@@ -26,18 +26,18 @@ weight(uniform_sampler,[0.5,0.0,4.0])
 struct UniformSampler{DIM,D} <: AbstractProposalSampler
     dist::D
 
-    function UniformSampler(lower_bounds::AbstractVector,upper_bounds::AbstractVector) 
-        dist = product_distribution(Uniform.(lower_bounds,upper_bounds))
+    function UniformSampler(lower_bounds::AbstractVector, upper_bounds::AbstractVector)
+        dist = product_distribution(Uniform.(lower_bounds, upper_bounds))
         return new{typeof(dist)}(dist)
     end
 end
 
-function setup(::UniformSampler) 
+function setup(::UniformSampler)
     @warn "Uniform sampler does not need a setup."
     return nothing
 end
 
-function train!(::UniformSampler, config...) 
+function train!(::UniformSampler, config...)
     @warn "Uniform sampler does not need to be trained."
     return nothing
 end
@@ -45,15 +45,13 @@ end
 # TODO: generalize this! -> write issue about this! 
 Base.eltype(::UniformSampler) = Float64
 
-
 Base.size(s::UniformSampler) = size(s.dist)
 Base.size(s::UniformSampler, k) = size(s)[k]
 
-function _weight(u::UniformSampler,x)
-    pdf(u.dist,x)
+function _weight(u::UniformSampler, x)
+    return pdf(u.dist, x)
 end
 
 function _rand!(rng::AbstractRNG, u::UniformSampler, x::AbstractVecOrMat{T}) where {T<:Real}
     return Distributions.rand!(rng, u.dist, x)
 end
-

--- a/test/interfaces/sampler_interface.jl
+++ b/test/interfaces/sampler_interface.jl
@@ -59,14 +59,14 @@ end
         x_out = rand(RNG, DIM)
 
         @test_throws MethodError setup(test_smplr_failed)
-        @test_throws MethodError is_exact(test_smplr_failed) 
+        @test_throws MethodError is_exact(test_smplr_failed)
         @test_throws MethodError size(test_smplr_failed)
         @test_throws MethodError max_weight(test_smplr_failed)
         @test_throws MethodError weight(test_smplr_failed, x_out)
 
         test_x_inplace = zeros(DIM)
-        @test_throws MethodError rand!(RNG,test_smplr_failed,test_x_inplace)
-        @test_throws MethodError rand(RNG,test_smplr_failed)
+        @test_throws MethodError rand!(RNG, test_smplr_failed, test_x_inplace)
+        @test_throws MethodError rand(RNG, test_smplr_failed)
     end
     @testset "process sampler interface" begin
         proc_stp = TestSetup(DIM)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,4 +6,8 @@ using SafeTestsets
     @time @safetestset "sampler interfaces" begin
         include("interfaces/sampler_interface.jl")
     end
+
+    @time @safetestset "uniform sampler" begin
+        include("sampler/uniform.jl")
+    end
 end

--- a/test/sampler/uniform.jl
+++ b/test/sampler/uniform.jl
@@ -1,0 +1,27 @@
+using QEDprocesses
+using QEDevents
+using QEDbase
+using Random
+
+RNG = MersenneTwister(137137137)
+
+ATOL = 0.0
+RTOL = sqrt(eps())
+
+struct TestSetup <: AbstractComputationSetup end
+test_setup = TestSetup()
+
+DIMS = [1,rand(RNG,2:8),rand(RNG,9:30)]
+
+
+_volume(bounds) = prod([b[2]-b[1] for b in bounds])
+
+@testset "dim: $dim" for dim in DIMS
+    bounds = [[-rand(RNG),rand(RNG)] for _ in 1:dim]
+    uniform_sampler = UniformSampler(test_setup,bounds)
+
+    @testset "pdf" begin
+        test_weight = weight(uniform_sampler,zeros(dim))
+        @test isapprox(test_weight,inv(_volume(bounds)))
+    end
+end

--- a/test/sampler/uniform.jl
+++ b/test/sampler/uniform.jl
@@ -8,18 +8,54 @@ RNG = MersenneTwister(137137137)
 ATOL = 0.0
 RTOL = sqrt(eps())
 
-struct TestSetup <: AbstractComputationSetup end
-test_setup = TestSetup()
-
 DIMS = [1,rand(RNG,2:8),rand(RNG,9:30)]
 
+# volume of a box with bounds
+_volume(bounds) = prod(bounds[2] .- bounds[1])
 
-_volume(bounds) = prod([b[2]-b[1] for b in bounds])
+
+@testset "sampler interface" begin
+    @test hasmethod( QEDevents._weight, Tuple{UniformSampler, <: Union{}})
+    @test hasmethod( Base.eltype, Tuple{UniformSampler})
+    @test hasmethod(Base.size, Tuple{UniformSampler})
+    @test hasmethod(QEDevents.setup, Tuple{UniformSampler})
+    @test hasmethod(QEDevents.train!, Tuple{UniformSampler, <:Union{}})
+    @test hasmethod(QEDevents._rand!, Tuple{<:AbstractRNG, UniformSampler, <:AbstractVector})
+end
 
 @testset "dim: $dim" for dim in DIMS
-    bounds = [[-rand(RNG),rand(RNG)] for _ in 1:dim]
-    uniform_sampler = UniformSampler(test_setup,bounds)
+    bounds = [-rand(RNG,dim),rand(RNG,dim)]
+    uniform_sampler = UniformSampler(bounds...)
 
+    @testset "rand: vector" begin
+        # reproduce the same random samples three times
+        rng1 = deepcopy(RNG)
+        rng2 = deepcopy(RNG)
+        rng3 = deepcopy(RNG)
+
+        test_x_inplace = zeros(dim)
+        rand!(rng1, uniform_sampler, test_x_inplace)
+        test_x = rand(rng2, uniform_sampler)
+        groundtruth = rand(rng3, uniform_sampler.dist)
+
+        @test isapprox(test_x_inplace, groundtruth, atol=ATOL, rtol=RTOL)
+        @test isapprox(test_x, groundtruth, atol=ATOL, rtol=RTOL)
+    end
+
+    @testset "rand: matrix" begin
+        # reproduce the same random samples three times
+        rng1 = deepcopy(RNG)
+        rng2 = deepcopy(RNG)
+        rng3 = deepcopy(RNG)
+
+        test_x_inplace = zeros(dim, 2)
+        rand!(rng1, uniform_sampler, test_x_inplace)
+        test_x = rand(rng2, uniform_sampler, 2)
+        groundtruth = rand(rng3, uniform_sampler.dist, 2)
+
+        @test isapprox(test_x_inplace, groundtruth, atol=ATOL, rtol=RTOL)
+        @test isapprox(test_x, groundtruth, atol=ATOL, rtol=RTOL)
+    end 
     @testset "pdf" begin
         test_weight = weight(uniform_sampler,zeros(dim))
         @test isapprox(test_weight,inv(_volume(bounds)))

--- a/test/sampler/uniform.jl
+++ b/test/sampler/uniform.jl
@@ -8,23 +8,22 @@ RNG = MersenneTwister(137137137)
 ATOL = 0.0
 RTOL = sqrt(eps())
 
-DIMS = [1,rand(RNG,2:8),rand(RNG,9:30)]
+DIMS = [1, rand(RNG, 2:8), rand(RNG, 9:30)]
 
 # volume of a box with bounds
 _volume(bounds) = prod(bounds[2] .- bounds[1])
 
-
 @testset "sampler interface" begin
-    @test hasmethod( QEDevents._weight, Tuple{UniformSampler, <: Union{}})
-    @test hasmethod( Base.eltype, Tuple{UniformSampler})
+    @test hasmethod(QEDevents._weight, Tuple{UniformSampler,<:Union{}})
+    @test hasmethod(Base.eltype, Tuple{UniformSampler})
     @test hasmethod(Base.size, Tuple{UniformSampler})
     @test hasmethod(QEDevents.setup, Tuple{UniformSampler})
-    @test hasmethod(QEDevents.train!, Tuple{UniformSampler, <:Union{}})
-    @test hasmethod(QEDevents._rand!, Tuple{<:AbstractRNG, UniformSampler, <:AbstractVector})
+    @test hasmethod(QEDevents.train!, Tuple{UniformSampler,<:Union{}})
+    @test hasmethod(QEDevents._rand!, Tuple{<:AbstractRNG,UniformSampler,<:AbstractVector})
 end
 
 @testset "dim: $dim" for dim in DIMS
-    bounds = [-rand(RNG,dim),rand(RNG,dim)]
+    bounds = [-rand(RNG, dim), rand(RNG, dim)]
     uniform_sampler = UniformSampler(bounds...)
 
     @testset "rand: vector" begin
@@ -55,9 +54,9 @@ end
 
         @test isapprox(test_x_inplace, groundtruth, atol=ATOL, rtol=RTOL)
         @test isapprox(test_x, groundtruth, atol=ATOL, rtol=RTOL)
-    end 
+    end
     @testset "pdf" begin
-        test_weight = weight(uniform_sampler,zeros(dim))
-        @test isapprox(test_weight,inv(_volume(bounds)))
+        test_weight = weight(uniform_sampler, zeros(dim))
+        @test isapprox(test_weight, inv(_volume(bounds)))
     end
 end


### PR DESCRIPTION
This PR adds uniform proposal sampler for hypercubes of floats in arbitrary dimensions. It mostly acts as the baseline for proposals of  coordinate-based cross sections. Currently, the uniform proposal sampler is initialized by the respective boundaries, but in the future, this will be done by a given scattering process setup and their phase space definition. 

Additionally, this PR refines some doc strings and adds the general proposal sampler interface by adding the `train!` function, which is supposed to act on concrete implementations of `AbstractProposalSampler`. 