### PR TITLE
Refactoring QED.jl

### DIFF
--- a/.github/workflows/BuildDelopyDoc.yml
+++ b/.github/workflows/BuildDelopyDoc.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-          julia --project=docs/ use_QEDprocesses_dev.jl
+          julia --project=docs/ add_QED_dev.jl
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,7 +11,7 @@ stages:
     - git clone --depth 1 -b dev https://github.com/QEDjl-project/QED.jl.git /QEDjl
     - julia --project=. -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/QEDjl-project/registry.git"));'
     - julia --project=. -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/JuliaRegistries/General"));'
-    - julia --project=. use_QEDprocesses_dev.jl
+    - julia --project=. add_QED_dev.jl
     - >
       if [[ $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_REF_NAME == "main" || $CI_COMMIT_BRANCH == "dev" || $CI_COMMIT_REF_NAME == "dev" ]]; then
         # set name of the commit message from CI_COMMIT_MESSAGE to NO_MESSAGE, that the script does not read accidentally custom packages from the commit message of a merge commit

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 QEDbase = "10e22c08-3ccb-4172-bfcf-7d7aa3d04d93"
+QEDcore = "35dc0263-cb5f-4c33-a114-1d7f54ab753e"
 QEDprocesses = "46de9c38-1bb3-4547-a1ec-da24d767fdad"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,12 @@
 name = "QEDevents"
 uuid = "fc3ce04a-5be5-4f3a-acff-eceaab723759"
-authors = ["Uwe Hernandez Acosta <u.hernandez@hzdr.de>", "Simeon Ehrig", "Klaus Steiniger", "Tom Jungnickel", "Anton Reinhard"]
+authors = [
+    "Uwe Hernandez Acosta <u.hernandez@hzdr.de>",
+    "Simeon Ehrig",
+    "Klaus Steiniger",
+    "Tom Jungnickel",
+    "Anton Reinhard",
+]
 version = "0.1.0"
 
 [deps]
@@ -13,3 +19,11 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 julia = "1.6"
+
+[extras]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Random", "SafeTestsets", "Test"]

--- a/add_QED_dev.jl
+++ b/add_QED_dev.jl
@@ -1,0 +1,9 @@
+
+using Pkg: Pkg
+
+Pkg.add(; url="https://github.com/QEDjl-project/QEDcore.jl", rev="dev")
+@warn "This repository depends on the dev branch of QEDcore.jl\n It is NOT ready for release!"
+
+Pkg.add(; url="https://github.com/QEDjl-project/QEDprocesses.jl", rev="dev")
+@warn """This repository depends on the dev branch of QEDprocesses.jl\n
+        It is NOT ready for release!"""

--- a/src/QEDevents.jl
+++ b/src/QEDevents.jl
@@ -9,7 +9,8 @@ import Random: AbstractRNG
 import Distributions: rand, rand!, _rand!
 using Distributions: Distributions
 
-using QEDbase
+using QEDbase: QEDbase
+using QEDcore
 using QEDprocesses
 
 using DocStringExtensions

--- a/src/interfaces/multi_particle_distribution.jl
+++ b/src/interfaces/multi_particle_distribution.jl
@@ -60,8 +60,8 @@ function randmom end
 # recursion termination: overload for unequal number of particles
 @inline function _recursive_type_check(
     ::Tuple{Vararg{ParticleStateful,N}},
-    ::Tuple{Vararg{AbstractParticleType,M}},
-    ::Tuple{Vararg{ParticleDirection,M}},
+    ::Tuple{Vararg{QEDbase.AbstractParticleType,M}},
+    ::Tuple{Vararg{QEDbase.ParticleDirection,M}},
 ) where {N,M}
     throw(InvalidInputError("expected $(M) particles but got $(N)"))
     return nothing
@@ -70,14 +70,14 @@ end
 # recursion termination: overload for invalid types
 @inline function _recursive_type_check(
     ::Tuple{ParticleStateful{DIR_IN_T,SPECIES_IN_T},Vararg{ParticleStateful,N}},
-    ::Tuple{SPECIES_T,Vararg{AbstractParticleType,N}},
-    ::Tuple{DIR_T,Vararg{ParticleDirection,N}},
+    ::Tuple{SPECIES_T,Vararg{QEDbase.AbstractParticleType,N}},
+    ::Tuple{DIR_T,Vararg{QEDbase.ParticleDirection,N}},
 ) where {
     N,
-    DIR_IN_T<:ParticleDirection,
-    DIR_T<:ParticleDirection,
-    SPECIES_IN_T<:AbstractParticleType,
-    SPECIES_T<:AbstractParticleType,
+    DIR_IN_T<:QEDbase.ParticleDirection,
+    DIR_T<:QEDbase.ParticleDirection,
+    SPECIES_IN_T<:QEDbase.AbstractParticleType,
+    SPECIES_T<:QEDbase.AbstractParticleType,
 }
     throw(
         InvalidInputError(
@@ -89,9 +89,9 @@ end
 
 @inline function _recursive_type_check(
     t::Tuple{ParticleStateful{DIR_T,SPECIES_T},Vararg{ParticleStateful,N}},
-    p::Tuple{SPECIES_T,Vararg{AbstractParticleType,N}},
-    dir::Tuple{DIR_T,Vararg{ParticleDirection,N}},
-) where {N,DIR_T<:ParticleDirection,SPECIES_T<:AbstractParticleType}
+    p::Tuple{SPECIES_T,Vararg{QEDbase.AbstractParticleType,N}},
+    dir::Tuple{DIR_T,Vararg{QEDbase.ParticleDirection,N}},
+) where {N,DIR_T<:QEDbase.ParticleDirection,SPECIES_T<:QEDbase.AbstractParticleType}
     return _recursive_type_check(t[2:end], p[2:end], dir[2:end])
 end
 
@@ -110,10 +110,10 @@ end
 @inline _assemble_tuple_types(::Tuple{}, ::Tuple{}, ::Type) = ()
 
 @inline function _assemble_tuple_types(
-    particle_types::Tuple{SPECIES_T,Vararg{AbstractParticleType}},
-    dir::Tuple{DIR_T,Vararg{ParticleDirection}},
+    particle_types::Tuple{SPECIES_T,Vararg{QEDbase.AbstractParticleType}},
+    dir::Tuple{DIR_T,Vararg{QEDbase.ParticleDirection}},
     ELTYPE::Type,
-) where {SPECIES_T<:AbstractParticleType,DIR_T<:ParticleDirection}
+) where {SPECIES_T<:QEDbase.AbstractParticleType,DIR_T<:QEDbase.ParticleDirection}
     return (
         ParticleStateful{DIR_T,SPECIES_T,ELTYPE},
         _assemble_tuple_types(particle_types[2:end], dir[2:end], ELTYPE)...,

--- a/src/patch_QEDbase.jl
+++ b/src/patch_QEDbase.jl
@@ -2,7 +2,7 @@
 @warn "This repository contains patches for QEDbase.jl\n It is NOT ready for release!"
 
 # See https://github.com/QEDjl-project/QEDbase.jl/issues/69
-struct UnknownDirection <: ParticleDirection end
+struct UnknownDirection <: QEDbase.ParticleDirection end
 Broadcast.broadcastable(d::UnknownDirection) = Ref(d)
 
 is_incoming(::UnknownDirection) = false

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,7 +1,0 @@
-[deps]
-Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
-QEDbase = "10e22c08-3ccb-4172-bfcf-7d7aa3d04d93"
-QEDprocesses = "46de9c38-1bb3-4547-a1ec-da24d767fdad"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/interfaces/multi_particle_distribution.jl
+++ b/test/interfaces/multi_particle_distribution.jl
@@ -1,7 +1,8 @@
 
 using QEDprocesses
 using QEDevents
-using QEDbase
+using QEDbase: QEDbase
+using QEDcore
 using Random: Random
 import Random: AbstractRNG, MersenneTwister, default_rng
 
@@ -16,10 +17,10 @@ RNG = MersenneTwister(137137137)
 ATOL = 0.0
 RTOL = sqrt(eps())
 
-struct WrongParticle <: AbstractParticleType end # for type checking in weight
-struct WrongDirection <: ParticleDirection end # for type checking in weight
+struct WrongParticle <: QEDbase.AbstractParticleType end # for type checking in weight
+struct WrongDirection <: QEDbase.ParticleDirection end # for type checking in weight
 
-DIRECTIONS = (Incoming(), Outgoing(), QEDevents.UnknownDirection())
+DIRECTIONS = (QEDbase.Incoming(), QEDbase.Outgoing(), QEDevents.UnknownDirection())
 RND_SEED = ceil(Int, 1e6 * rand(RNG)) # for comparison
 @testset "N=$N" for N in (1, rand(RNG, 2:10))
     @testset "default properties" begin

--- a/test/interfaces/single_particle_distribution.jl
+++ b/test/interfaces/single_particle_distribution.jl
@@ -1,6 +1,7 @@
 using QEDprocesses
 using QEDevents
-using QEDbase
+using QEDbase: QEDbase
+using QEDcore
 using Random: Random
 import Random: AbstractRNG, MersenneTwister, default_rng
 
@@ -17,10 +18,10 @@ ATOL = 0.0
 RTOL = sqrt(eps())
 
 test_particle = rand(RNG, TestImpl.PARTICLE_SET)
-struct WrongParticle <: AbstractParticleType end # for type checking in weight
-struct WrongDirection <: ParticleDirection end # for type checking in weight
+struct WrongParticle <: QEDbase.AbstractParticleType end # for type checking in weight
+struct WrongDirection <: QEDbase.ParticleDirection end # for type checking in weight
 
-DIRECTIONS = (Incoming(), Outgoing(), QEDevents.UnknownDirection())
+DIRECTIONS = (QEDbase.Incoming(), QEDbase.Outgoing(), QEDevents.UnknownDirection())
 RND_SEED = ceil(Int, 1e6 * rand(RNG)) # for comparison
 
 @testset "default properties" begin

--- a/test/test_implementation/TestImpl.jl
+++ b/test/test_implementation/TestImpl.jl
@@ -1,6 +1,7 @@
 module TestImpl
 
-using QEDbase
+using QEDbase: QEDbase
+using QEDcore
 using QEDprocesses
 using QEDevents
 using Distributions

--- a/test/test_implementation/groundtruths/multi_particle.jl
+++ b/test/test_implementation/groundtruths/multi_particle.jl
@@ -3,5 +3,5 @@ function _groundtruth_multi_randmom(rng, d)
 end
 
 function _groundtruth_multi_weight(dist, psfs)
-    @. getE(momentum(psfs))
+    @. QEDbase.getE(momentum(psfs))
 end

--- a/test/test_implementation/groundtruths/single_particle.jl
+++ b/test/test_implementation/groundtruths/single_particle.jl
@@ -6,5 +6,5 @@ function _groundtruth_single_rand(rng, dist)
 end
 
 function _groundtruth_single_weight(dist, x::ParticleStateful)
-    return getE(momentum(x))
+    return QEDbase.getE(momentum(x))
 end

--- a/test/test_implementation/groundtruths/test_process.jl
+++ b/test/test_implementation/groundtruths/test_process.jl
@@ -59,8 +59,8 @@ end
 Test implementation of the phase space factor. Return the inverse of the product of the energies of all external particles.
 """
 function _groundtruth_phase_space_factor(in_ps, out_ps)
-    en_in = getE.(in_ps)
-    en_out = getE.(out_ps)
+    en_in = QEDbase.getE.(in_ps)
+    en_out = QEDbase.getE.(out_ps)
     return 1 / (prod(en_in) * prod(en_out))
 end
 

--- a/test/test_implementation/multi_particle_dist.jl
+++ b/test/test_implementation/multi_particle_dist.jl
@@ -1,5 +1,5 @@
 
-PARTICLE_DIRECTIONS = (Incoming(), Outgoing(), QEDevents.UnknownDirection())
+PARTICLE_DIRECTIONS = (QEDbase.Incoming(), QEDbase.Outgoing(), QEDevents.UnknownDirection())
 
 struct TestMultiParticleDist{DT<:Tuple,PT<:Tuple,RT} <: MultiParticleDistribution
     dirs::DT

--- a/test/test_implementation/single_particle_dist.jl
+++ b/test/test_implementation/single_particle_dist.jl
@@ -10,11 +10,13 @@ struct TestSingleParticleDist{D,P,T} <: SingleParticleDistribution
     mom_type::Type{T}
 end
 
-function TestSingleParticleDist(part::AbstractParticleType)
+function TestSingleParticleDist(part::QEDbase.AbstractParticleType)
     return TestSingleParticleDist(QEDevents.UnknownDirection(), part, SFourMomentum)
 end
 
-function TestSingleParticleDist(dir::ParticleDirection, part::AbstractParticleType)
+function TestSingleParticleDist(
+    dir::QEDbase.ParticleDirection, part::QEDbase.AbstractParticleType
+)
     return TestSingleParticleDist(dir, part, SFourMomentum)
 end
 

--- a/test/test_implementation/test_particles.jl
+++ b/test/test_implementation/test_particles.jl
@@ -1,7 +1,7 @@
 
 # dummy particles
-struct TestParticle <: AbstractParticleType end # generic particle
-struct TestParticleFermion <: FermionLike end
-struct TestParticleBoson <: BosonLike end
+struct TestParticle <: QEDbase.AbstractParticleType end # generic particle
+struct TestParticleFermion <: QEDbase.FermionLike end
+struct TestParticleBoson <: QEDbase.BosonLike end
 
 const PARTICLE_SET = [TestParticleFermion(), TestParticleBoson()]

--- a/test/test_implementation/test_process.jl
+++ b/test/test_implementation/test_process.jl
@@ -78,5 +78,5 @@ end
 function QEDprocesses._total_probability(
     in_psp::InPhaseSpacePoint{<:TestProcess,<:TestModel,<:TestPhasespaceDef}
 )
-    return _groundtruth_total_probability(momenta(in_psp, Incoming()))
+    return _groundtruth_total_probability(momenta(in_psp, QEDbase.Incoming()))
 end


### PR DESCRIPTION
This opts out the `QEDbase` namespace and adds the dependency on `QEDcore`. 

This is part of the general restructuring of `QED.jl`, see https://github.com/QEDjl-project/QED.jl/issues/35 for details. 