### PR TITLE
Move randmom to ParticleSampleable

### DIFF
--- a/src/QEDevents.jl
+++ b/src/QEDevents.jl
@@ -3,7 +3,7 @@ module QEDevents
 export weight
 
 export SingleParticleDistribution
-export MultiParticleDistribution, randmom
+export MultiParticleDistribution
 
 import Random: AbstractRNG
 import Distributions: rand, rand!, _rand!

--- a/src/interfaces/multi_particle_distribution.jl
+++ b/src/interfaces/multi_particle_distribution.jl
@@ -46,14 +46,6 @@ function _particle_direction(d::MultiParticleDistribution)
     return Tuple(fill(UnknownDirection(), length(d)))
 end
 
-"""
-
-    _randmom(rng::AbstractRNG,d::MultiParticleDistribution)
-
-Return an iterable container (e.g. vector or tuple) of momenta according to the distribution `d`.
-"""
-function _randmom end
-
 # recursion termination: success
 @inline _recursive_type_check(::Tuple{}, ::Tuple{}, ::Tuple{}) = nothing
 

--- a/src/interfaces/multi_particle_distribution.jl
+++ b/src/interfaces/multi_particle_distribution.jl
@@ -8,7 +8,7 @@ should be implemented:
 
 * [`QEDevents._particles(d::MultiParticleDistribution)`](@ref)
 * [`QEDevents._particle_directions(d::MultiParticleDistribution)`](@ref)
-* [`QEDevents.randmom(rng::AbstractRNG,d::MultiParticleDistribution)`](@ref)
+* [`QEDevents._randmom(rng::AbstractRNG,d::MultiParticleDistribution)`](@ref)
 
 """
 const MultiParticleDistribution = ParticleSampleable{MultiParticleVariate}
@@ -48,11 +48,11 @@ end
 
 """
 
-    randmom(rng::AbstractRNG,d::MultiParticleDistribution)
+    _randmom(rng::AbstractRNG,d::MultiParticleDistribution)
 
 Return an iterable container (e.g. vector or tuple) of momenta according to the distribution `d`.
 """
-function randmom end
+function _randmom end
 
 # recursion termination: success
 @inline _recursive_type_check(::Tuple{}, ::Tuple{}, ::Tuple{}) = nothing
@@ -129,7 +129,7 @@ end
 
 function Distributions.rand(rng::AbstractRNG, d::MultiParticleDistribution)
     n = length(d)
-    moms = randmom(rng, d)
+    moms = _randmom(rng, d)
     dirs = _particle_directions(d)
     parts = _particles(d)
 

--- a/src/interfaces/single_particle_distribution.jl
+++ b/src/interfaces/single_particle_distribution.jl
@@ -8,7 +8,7 @@ should be implemented:
 
 * [`QEDevents._particle(d::SingleParticleDistribution)`](@ref): return associated particle
 * [`QEDevents._particle_direction(d::SingleParticleDistribution)`](@ref): return associated particle direction
-* `Distributions.rand(rng::AbstractRNG,d::SingleParticleDistribution)`: return random sample as a `ParticleStateful`
+* [`QEDevents._randmom(d::SingleParticleDistribution)`](@ref): return momentum according to `d`
 
 """
 const SingleParticleDistribution = ParticleSampleable{SingleParticleVariate}
@@ -64,4 +64,9 @@ function Base.eltype(s::SingleParticleDistribution)
     return ParticleStateful{
         typeof(_particle_direction(s)),typeof(_particle(s)),_momentum_type(s)
     }
+end
+
+function Distributions.rand(rng::AbstractRNG, d::SingleParticleDistribution)
+    rnd_momentum = _randmom(rng, d)
+    return ParticleStateful(_particle_direction(d), _particle(d), rnd_momentum)
 end

--- a/test/interfaces/single_particle_distribution.jl
+++ b/test/interfaces/single_particle_distribution.jl
@@ -41,50 +41,68 @@ end
             ParticleStateful{typeof(dir),typeof(test_particle),SFourMomentum}
     end
 
-    @testset "single sample" begin
-        Random.seed!(RND_SEED)
-        rng = default_rng()
-        psf_groundtruth = TestImpl._groundtruth_single_rand(rng, test_dist)
+    @testset "randmom" begin
+        @testset "single sample" begin
+            Random.seed!(RND_SEED)
+            rng = default_rng()
+            mom_groundtruth = TestImpl._groundtruth_single_randmom(rng, test_dist)
 
-        Random.seed!(RND_SEED)
-        rng = default_rng()
-        psf_rng = @inferred rand(rng, test_dist)
+            Random.seed!(RND_SEED)
+            rng = default_rng()
+            mom_rng = @inferred QEDevents._randmom(rng, test_dist)
 
-        Random.seed!(RND_SEED)
-        psf_default = @inferred rand(test_dist)
-
-        @test psf_groundtruth == psf_rng
-        @test psf_rng == psf_default
+            @test mom_groundtruth == mom_rng
+        end
     end
 
-    @testset "multiple samples" begin
-        @testset "$dim" for dim in (1, 2, 3)
-            checked_lengths = (1, rand(RNG, 1:10))
-            shapes = Iterators.product(fill(checked_lengths, dim)...)
+    @testset "rand" begin
+        @testset "single sample" begin
+            Random.seed!(RND_SEED)
+            rng = default_rng()
+            mom_groundtruth = TestImpl._groundtruth_single_randmom(rng, test_dist)
+            psf_groundtruth = ParticleStateful(dir, test_particle, mom_groundtruth)
 
-            @testset "$shape" for shape in shapes
-                Random.seed!(RND_SEED)
-                rng = default_rng()
-                psf_rng = @inferred rand(rng, test_dist, shape...)
+            Random.seed!(RND_SEED)
+            rng = default_rng()
+            psf_rng = @inferred rand(rng, test_dist)
 
-                Random.seed!(RND_SEED)
-                psf_default = @inferred rand(test_dist, shape...)
+            Random.seed!(RND_SEED)
+            psf_default = @inferred rand(test_dist)
 
-                Random.seed!(RND_SEED)
-                rng = default_rng()
-                mom_prealloc_rng = Array{SFourMomentum}(undef, shape...)
-                psf_prealloc_rng = ParticleStateful.(dir, test_particle, mom_prealloc_rng)
-                @inferred Random.rand!(rng, test_dist, psf_prealloc_rng)
+            @test psf_groundtruth == psf_rng
+            @test psf_rng == psf_default
+        end
 
-                Random.seed!(RND_SEED)
-                mom_prealloc_default = Array{SFourMomentum}(undef, shape)
-                psf_prealloc_default =
-                    ParticleStateful.(dir, test_particle, mom_prealloc_default)
-                @inferred Random.rand!(test_dist, psf_prealloc_default)
+        @testset "multiple samples" begin
+            @testset "$dim" for dim in (1, 2, 3)
+                checked_lengths = (1, rand(RNG, 1:10))
+                shapes = Iterators.product(fill(checked_lengths, dim)...)
 
-                @test all(psf_rng == psf_default)
-                @test all(psf_rng == psf_prealloc_rng)
-                @test all(psf_rng == psf_prealloc_default)
+                @testset "$shape" for shape in shapes
+                    Random.seed!(RND_SEED)
+                    rng = default_rng()
+                    psf_rng = @inferred rand(rng, test_dist, shape...)
+
+                    Random.seed!(RND_SEED)
+                    psf_default = @inferred rand(test_dist, shape...)
+
+                    Random.seed!(RND_SEED)
+                    rng = default_rng()
+                    mom_prealloc_rng = Array{SFourMomentum}(undef, shape...)
+                    psf_prealloc_rng =
+                        ParticleStateful.(dir, test_particle, mom_prealloc_rng)
+                    @inferred Random.rand!(rng, test_dist, psf_prealloc_rng)
+
+                    Random.seed!(RND_SEED)
+                    mom_prealloc_default = Array{SFourMomentum}(undef, shape)
+                    psf_prealloc_default =
+                        ParticleStateful.(dir, test_particle, mom_prealloc_default)
+                    @inferred Random.rand!(test_dist, psf_prealloc_default)
+
+                    @test all(psf_rng == psf_default)
+                    @test all(psf_rng == psf_prealloc_rng)
+                    @test all(psf_rng == psf_prealloc_default)
+                end
             end
         end
     end

--- a/test/test_implementation/groundtruths/single_particle.jl
+++ b/test/test_implementation/groundtruths/single_particle.jl
@@ -1,8 +1,6 @@
-function _groundtruth_single_rand(rng, dist)
-    rnd_mom = rand(rng, SFourMomentum)
-    return ParticleStateful(
-        QEDevents._particle_direction(dist), QEDevents._particle(dist), rnd_mom
-    )
+# Returns a random momentum, where all componets are uniformly distributed.
+function _groundtruth_single_randmom(rng::AbstractRNG, dist)
+    return rand(rng, SFourMomentum)
 end
 
 function _groundtruth_single_weight(dist, x::ParticleStateful)

--- a/test/test_implementation/multi_particle_dist.jl
+++ b/test/test_implementation/multi_particle_dist.jl
@@ -16,7 +16,7 @@ end
 
 QEDevents._particle_directions(d::TestMultiParticleDist) = d.dirs
 
-function QEDevents.randmom(rng::AbstractRNG, d::TestMultiParticleDist)
+function QEDevents._randmom(rng::AbstractRNG, d::TestMultiParticleDist)
     return _groundtruth_multi_randmom(rng, d)
 end
 

--- a/test/test_implementation/single_particle_dist.jl
+++ b/test/test_implementation/single_particle_dist.jl
@@ -22,8 +22,8 @@ QEDevents._particle(d::TestSingleParticleDist) = d.part
 QEDevents._particle_direction(d::TestSingleParticleDist) = d.dir
 QEDevents._momentum_type(d::TestSingleParticleDist{D,P,T}) where {D,P,T} = T
 
-function Distributions.rand(rng::AbstractRNG, d::TestSingleParticleDist)
-    return _groundtruth_single_rand(rng, d)
+function QEDevents._randmom(rng::AbstractRNG, d::TestSingleParticleDist)
+    return _groundtruth_single_randmom(rng, d)
 end
 
 function QEDevents._weight(d::TestSingleParticleDist, x::ParticleStateful)


### PR DESCRIPTION
This PR streamlines the `randmom` function by using it as a general interface function. Summary of the changes: 

- moved `randmom` to the definition of the general `ParticleSampleable` interface
- updated the docstrings accordingly
- updated the single-particle distribution using `randmom`
- updated the tests accordingly

Finally, to encourage users to use `rand` (and respective versions) instead of `randmom`, the latter is made private and renamed to `_randmom`. 