### PR TITLE
Fix compathelper repository url

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -8,7 +8,7 @@ permissions:
   pull-requests: write
 jobs:
   CompatHelper:
-    if: github.repository == 'QEDjl-project/QEDfields.jl'
+    if: github.repository == 'QEDjl-project/QEDevents.jl'
     runs-on: ubuntu-latest
     steps:
       - name: Check if Julia is already available in the PATH
@@ -42,5 +42,4 @@ jobs:
         shell: julia --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
           COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}


### PR DESCRIPTION
As the title says, when we set this up we must have forgotten to update the repository URL from QEDfields. Therefore it did not run until now.