### PR TITLE
Fix CI scripts and compat entries for QEDbase and core

### DIFF
--- a/.github/workflows/BuildDeployDoc.yml
+++ b/.github/workflows/BuildDeployDoc.yml
@@ -18,15 +18,19 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
-          version: "1.10"
-      - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
-      - name: set dependencies to dev branch version
-        if: (github.event_name == 'push' && github.ref_name != 'main') || (github.event_name == 'pull_request' && github.base_ref != 'main')
+          version: '1.10'
+      - name: clone integration test tools
         run: |
-          git clone -b dev https://github.com/QEDjl-project/QuantumElectrodynamics.jl.git /tmp/integration_test_tools
-          julia --project=docs/ /tmp/integration_test_tools/.ci/set_dev_dependencies.jl
+          git clone --depth 1 -b dev https://github.com/QEDjl-project/QuantumElectrodynamics.jl.git /tmp/integration_test_tools/
+      - name: set dev dependencies
+        run: |
+          $(julia --project=. /tmp/integration_test_tools/.ci/integTestGen/src/get_project_name_version_path.jl)
+          echo "CI_DEV_PKG_NAME -> $CI_DEV_PKG_NAME"
+          echo "CI_DEV_PKG_VERSION -> $CI_DEV_PKG_VERSION"
+          echo "CI_DEV_PKG_PATH -> $CI_DEV_PKG_PATH"
+          julia --project=docs/ /tmp/integration_test_tools/.ci/SetupDevEnv/src/SetupDevEnv.jl
+          julia --project=docs/ -e 'import Pkg; Pkg.instantiate()'
       - name: Build and deploy
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: julia --project=docs/ docs/make.jl

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,17 +4,21 @@ stages:
   - run_integration_test
   - verify-unit-test-deps
 
-.untit_test_template:
+.unit_test_template:
   stage: unit-test
   script:
     - apt update && apt install -y git
-    - git clone --depth 1 -b dev https://github.com/QEDjl-project/QuantumElectrodynamics.jl.git /QEDjl
+    - git clone --depth 1 -b dev https://github.com/QEDjl-project/QuantumElectrodynamics.jl.git /tmp/integration_test_tools/
+    - $(julia --project=. /tmp/integration_test_tools/.ci/integTestGen/src/get_project_name_version_path.jl)
+    - echo "CI_DEV_PKG_NAME -> $CI_DEV_PKG_NAME"
+    - echo "CI_DEV_PKG_VERSION -> $CI_DEV_PKG_VERSION"
+    - echo "CI_DEV_PKG_PATH -> $CI_DEV_PKG_PATH"
     - >
       if [[ $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_REF_NAME == "main" || $CI_COMMIT_BRANCH == "dev" || $CI_COMMIT_REF_NAME == "dev" ]]; then
         # set name of the commit message from CI_COMMIT_MESSAGE to NO_MESSAGE, that the script does not read accidentally custom packages from the commit message of a merge commit
-        julia --project=. /QEDjl/.ci/SetupDevEnv/src/SetupDevEnv.jl ${CI_PROJECT_DIR}/Project.toml NO_MESSAGE
+        julia --project=. /tmp/integration_test_tools/.ci/SetupDevEnv/src/SetupDevEnv.jl ${CI_PROJECT_DIR}/Project.toml NO_MESSAGE
       else
-        julia --project=. /QEDjl/.ci/SetupDevEnv/src/SetupDevEnv.jl ${CI_PROJECT_DIR}/Project.toml
+        julia --project=. /tmp/integration_test_tools/.ci/SetupDevEnv/src/SetupDevEnv.jl ${CI_PROJECT_DIR}/Project.toml
       fi
     - julia --project=. -e 'import Pkg; Pkg.instantiate()'
     - julia --project=. -e 'import Pkg; Pkg.test(; coverage = true)'
@@ -23,35 +27,35 @@ stages:
     - cpuonly
 
 unit_tests_releases:
-  extends: .untit_test_template
+  extends: .unit_test_template
   parallel:
     matrix:
       - JULIA_VERSION: ["1.10", "1.11", "rc"]
   image: julia:$JULIA_VERSION
 
 unit_tests_nightly:
-  extends: .untit_test_template
+  extends: .unit_test_template
   # use the same baseimage like the official julia images
   image: debian:bookworm-slim
   variables:
     # path where julia tar bal should be downloaded
-    JULIA_DONWLOAD: /julia/download
+    JULIA_DOWNLOAD: /julia/download
     # path where julia should be extracted
     JULIA_EXTRACT: /julia/extract
   before_script:
     - apt update && apt install -y wget
-    - mkdir -p $JULIA_DONWLOAD
+    - mkdir -p $JULIA_DOWNLOAD
     - mkdir -p $JULIA_EXTRACT
     - >
       if [[ $CI_RUNNER_EXECUTABLE_ARCH == "linux/arm64" ]]; then
-        wget https://julialangnightlies-s3.julialang.org/bin/linux/aarch64/julia-latest-linux-aarch64.tar.gz -O $JULIA_DONWLOAD/julia-nightly.tar.gz
+        wget https://julialangnightlies-s3.julialang.org/bin/linux/aarch64/julia-latest-linux-aarch64.tar.gz -O $JULIA_DOWNLOAD/julia-nightly.tar.gz
       elif [[ $CI_RUNNER_EXECUTABLE_ARCH == "linux/amd64" ]]; then
-        wget https://julialangnightlies-s3.julialang.org/bin/linux/x86_64/julia-latest-linux-x86_64.tar.gz -O $JULIA_DONWLOAD/julia-nightly.tar.gz
+        wget https://julialangnightlies-s3.julialang.org/bin/linux/x86_64/julia-latest-linux-x86_64.tar.gz -O $JULIA_DOWNLOAD/julia-nightly.tar.gz
       else
         echo "unknown runner architecture -> $CI_RUNNER_EXECUTABLE_ARCH"
         exit 1
       fi
-    - tar -xf $JULIA_DONWLOAD/julia-nightly.tar.gz -C $JULIA_EXTRACT
+    - tar -xf $JULIA_DOWNLOAD/julia-nightly.tar.gz -C $JULIA_EXTRACT
     # we need to search for the julia base folder name, because the second part of the name is the git commit hash
     # e.g. julia-b0c6781676f
     - JULIA_EXTRACT_FOLDER=${JULIA_EXTRACT}/$(ls $JULIA_EXTRACT | grep -m1 julia)
@@ -59,16 +63,20 @@ unit_tests_nightly:
     # mv is not possible, because it cannot merge folder
     - cp -r $JULIA_EXTRACT_FOLDER/* /usr
   allow_failure: true
+  tags:
+    - cpuonly
 
 generate_integration_tests:
   image: julia:1.10
   stage: generate_integration_test
   script:
     # extract package name
-    - export CI_DEPENDENCY_NAME=$(cat $CI_PROJECT_DIR/Project.toml | grep name | awk '{ print $3 }' | tr -d '"')
-    - echo "CI_DEPENDENCY_NAME -> $CI_DEPENDENCY_NAME"
     - apt update && apt install -y git
     - git clone --depth 1 -b dev https://github.com/QEDjl-project/QuantumElectrodynamics.jl.git /QEDjl
+    - $(julia --project /QEDjl/.ci/integTestGen/src/get_project_name_version_path.jl)
+    - echo "CI_DEV_PKG_NAME -> $CI_DEV_PKG_NAME"
+    - echo "CI_DEV_PKG_VERSION -> $CI_DEV_PKG_VERSION"
+    - echo "CI_DEV_PKG_PATH -> $CI_DEV_PKG_PATH"
     - cd /QEDjl/.ci/integTestGen/
     - julia --project=. -e 'import Pkg; Pkg.instantiate()'
     # paths of artifacts are relative to CI_PROJECT_DIR

--- a/Project.toml
+++ b/Project.toml
@@ -20,8 +20,8 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 [compat]
 Distributions = "0.25"
 DocStringExtensions = "0.9"
-QEDbase = "0.2.2"
-QEDcore = "0.1"
+QEDbase = "0.3"
+QEDcore = "0.2"
 StatsBase = "0.34"
 julia = "1.10"
 


### PR DESCRIPTION
Same as https://github.com/QEDjl-project/QEDprocesses.jl/pull/106

Makes #48 redundant, but we need to update the compat together with the update of the CI scripts to be able to merge.